### PR TITLE
switch action back to upstream

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Publish Helm Chart
-        uses: tylerauerbeck/helm-gh-pages@main
+        uses: stefanprodan/helm-gh-pages@master
         with:
           token: ${{ secrets.PUBLIC_REPO_GH_PAT }}
           charts_dir: governor-api


### PR DESCRIPTION
it can't find `Chart.yaml` but its in the `governor-api` dir, want to see if this is an issue with the action or now. 