### PR TITLE
remove trailing -api

### DIFF
--- a/charts/governor-api/templates/deployment.yml
+++ b/charts/governor-api/templates/deployment.yml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ template "common.names.fullname" . }}-api
+  name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: api
 spec:
@@ -32,7 +32,7 @@ spec:
           - mountPath: /app-audit
             name: audit-logs-api
       containers:
-      - name: {{ template "common.names.fullname" . }}-api
+      - name: {{ template "common.names.fullname" . }}
         args:
           - serve
           - "--config=/config/.governor.yaml"
@@ -100,7 +100,7 @@ spec:
           readOnly: true
         - name: audit-logs-api
           mountPath: /app-audit
-      - name: audit-{{ template "common.names.fullname" . }}-api
+      - name: audit-{{ template "common.names.fullname" . }}
         args:
           - -f
           - /app-audit/audit.log

--- a/charts/governor-api/templates/ingress.yml
+++ b/charts/governor-api/templates/ingress.yml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-  name: {{ template "common.names.fullname" . }}-api
+  name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   ingressClassName: nginx-governor
@@ -16,17 +16,17 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ template "common.names.fullname" $ }}-api
+                name: {{ template "common.names.fullname" $ }}
                 port:
                   name: http
           - path: "/healthz"
             pathType: Prefix
             backend:
               service:
-                name: {{ template "common.names.fullname" $ }}-api
+                name: {{ template "common.names.fullname" $ }}
                 port:
                   name: http
   tls:
     - hosts:
         - {{ .Values.api.ingress.host }}
-      secretName: {{ template "common.names.fullname" . }}-api-tls
+      secretName: {{ template "common.names.fullname" . }}-tls

--- a/charts/governor-api/templates/service-monitor.yml
+++ b/charts/governor-api/templates/service-monitor.yml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "common.names.fullname" . }}-api
+  name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   namespaceSelector:

--- a/charts/governor-api/templates/service.yml
+++ b/charts/governor-api/templates/service.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "common.names.fullname" . }}-api
+  name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: api
 spec:


### PR DESCRIPTION
The existing chart ends up with a stutter: `governor-governor-api-api` this should just be `governor-governor-api` 