### PR TITLE
fix audit image registry

### DIFF
--- a/charts/governor/templates/slack-addon-deployment.yaml
+++ b/charts/governor/templates/slack-addon-deployment.yaml
@@ -35,7 +35,7 @@ spec:
     {{- if .Values.audit.enabled }}
       initContainers:
       # Optional: Pre-creates the `/app-audit/audit.log` named pipe.
-      - image: "{{ .Values.audit.auditImage.registry }}/{{ .Values.audit.auditImage.repository }}:{{ .Values.audit.auditImage.tag | default .Chart.AppVersion }}"
+      - image: "{{ .Values.audit.auditImage.repository }}:{{ .Values.audit.auditImage.tag | default .Chart.AppVersion }}"
         {{- with .Values.audit.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
The registry and repo were combined, so this is causing the image to be `image: '/ghcr.io/metal-toolbox/audittail:v0.8.0'`. This PR removes the first slash