### PR TITLE
[DRAFT] optionally disable otel subchart, configure endpoint

### DIFF
--- a/charts/governor/Chart.yaml
+++ b/charts/governor/Chart.yaml
@@ -14,3 +14,4 @@ dependencies:
   - name: k8s-otel-collector
     repository: https://helm.equinixmetal.com
     version: 0.9.1
+    condition: otel-collector-enabled

--- a/charts/governor/templates/api-deployment.yml
+++ b/charts/governor/templates/api-deployment.yml
@@ -52,9 +52,9 @@ spec:
         {{- if .Values.api.tracing.enabled }}
         env:
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://opentelemetry-collector:4317
+            value: {{ .Values.api.tracing.endpoint }}
           - name: OTEL_EXPORTER_OTLP_INSECURE
-            value: "true"
+            value: {{ .Values.api.tracing.insecure }}
         {{- end }}
         image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.api.image.pullPolicy }}

--- a/charts/governor/values.yaml
+++ b/charts/governor/values.yaml
@@ -97,9 +97,12 @@ api:
       crdbCrt:
     uri:
       existingSecret: db-uri
+
   # -- tracing settings
   tracing:
     enabled: true
+    endpoint: "http://opentelemetry-collector:4317"
+    insecure: "true"
     # -- tracing secrets, set to `true` if you want to set the value directly in the chart (not recommended)
     secrets:
       enabled: false
@@ -221,6 +224,9 @@ audit:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 1000
+
+# -- Enable/disable deployment of the otel collector
+otel-collector-enabled: true
 
 # -- settings for the otel collector sub-chart
 # ref https://github.com/equinixmetal-helm/k8s-otel-collector


### PR DESCRIPTION
This PR adds the option to disable the inclusion of the otel subchart since you may not need to deploy the collector in cases where you disable tracing or you have another collector deployed outside of the chart. It also allows allows for configuration of the tracing endpoints for the governor-api deployment.